### PR TITLE
Add markdoc property to AppProps type

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -40,9 +40,7 @@ function collectHeadings(node, sections = []) {
   return sections;
 }
 
-export interface MyAppProps {
-  markdoc?: MarkdocNextJsPageProps['markdoc']
-}
+export type MyAppProps = MarkdocNextJsPageProps
 
 export default function MyApp({ Component, pageProps }: AppProps<MyAppProps>) {
   const { markdoc } = pageProps;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -12,6 +12,7 @@ import 'prismjs/themes/prism.css';
 import '../public/globals.css'
 
 import type { AppProps } from 'next/app'
+import type { MarkdocNextJsPageProps } from '@markdoc/next.js'
 
 const TITLE = 'Markdoc';
 const DESCRIPTION = 'A powerful, flexible, Markdown-based authoring framework';
@@ -39,7 +40,11 @@ function collectHeadings(node, sections = []) {
   return sections;
 }
 
-export default function MyApp({ Component, pageProps }: AppProps) {
+export interface MyAppProps {
+  markdoc?: MarkdocNextJsPageProps['markdoc']
+}
+
+export default function MyApp({ Component, pageProps }: AppProps<MyAppProps>) {
   const { markdoc } = pageProps;
 
   let title = TITLE;


### PR DESCRIPTION
### Issue

I noticed this is in an external project that was created from this template. After the update of Next.js `12.3.x`, the `AppProps` (extends `AppInitialProps`) type no longer has `pageProps` type set to `any`, this means that a type error is thrown when building the project.

### Solution

The solution here is to create a `MyAppProps` interface and add the `markdoc` property by setting its type to `MarkdocNextJsPageProps['markdoc']` (imported from `@markdoc/next.js`) and pass it to the `AppProps` type. This fix allows the build step to successfully pass the validity of types check.