### PR TITLE
Add examples of using next.js tags in markdoc.

### DIFF
--- a/markdoc/tags/Next.markdoc.ts
+++ b/markdoc/tags/Next.markdoc.ts
@@ -1,0 +1,1 @@
+export { comment, head, link, script } from '@markdoc/next.js/tags';

--- a/markdoc/tags/index.ts
+++ b/markdoc/tags/index.ts
@@ -1,2 +1,3 @@
 /* Use this file to export your markdoc tags */
 export * from './callout.markdoc';
+export * from './Next.markdoc';

--- a/markdoc_nextjs_tags.d.ts
+++ b/markdoc_nextjs_tags.d.ts
@@ -1,0 +1,1 @@
+declare module '@markdoc/next.js/tags';

--- a/pages/docs/index.md
+++ b/pages/docs/index.md
@@ -3,3 +3,31 @@ title: Overview
 ---
 
 # {% $markdoc.frontmatter.title %}
+
+## Example Next.js tags
+
+### Comment
+
+{% comment %}
+   This is a Next.js comment, this will not be rendered by markdoc.
+{% /comment %}
+
+### Script
+
+{% script src="example.js" strategy="lazyOnload" /%}
+
+### Link
+
+{% link href="https://markdoc.dev/" %}
+Markdoc.dev
+{% /link %}
+
+{% link href="/" %}
+markdoc-starter index page
+{% /link %}
+
+### Head
+
+{% head %}
+    <meta property="og:title" content="Overview" key="title" />
+{% /head %}

--- a/public/example.js
+++ b/public/example.js
@@ -1,0 +1,1 @@
+console.log('test of next.js script tag.');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,6 @@
     "isolatedModules": true,
     "jsx": "preserve"
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "markdoc_nextjs_tags.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
@mfix-stripe  Following up on https://github.com/markdoc/markdoc/issues/227 this PR adds example code for how to include the 4 Next.js tags which are provided by markdoc.

****

While testing this, I noticed there seems to be a rendering bug with the Head tag but only in next's production/optimized mode. To reproduce, run the current branch like this:

```
npm run build
npm run start
```

* Browse to localhost:3000 and then click the Docs link. The page renders OK, and the Head tag is output correctly to the browser as shown in view source.
* Reload your browser at url http://localhost:3000/docs then the page does not render, and outputs the raw Head tag content: 
* This problem does not occur when running next in development mode with `npm run dev`.

<img width="795" alt="Screen Shot 2022-10-03 at 4 02 57 PM" src="https://user-images.githubusercontent.com/766758/193694126-7b2ea2d9-d345-4b49-99ec-65c05dffcc4f.png">
