### PR TITLE
Upgrade to Next.js 13

### DIFF
--- a/components/SideNav.tsx
+++ b/components/SideNav.tsx
@@ -22,9 +22,7 @@ export function SideNav() {
               const active = router.pathname === link.href;
               return (
                 <li key={link.href} className={active ? 'active' : ''}>
-                  <Link href={link.href}>
-                    {link.children}
-                  </Link>
+                  <Link {...link} />
                 </li>
               );
             })}
@@ -54,11 +52,11 @@ export function SideNav() {
             list-style: none;
             margin: 0;
           }
-         :global(.sidenav li a) {
+          li :global(a) {
             text-decoration: none;
           }
-          :global(.sidenav li a:hover),
-          :global(.sidenav li.active > a) {
+          li :global(a:hover),
+          li.active :global(a) {
             text-decoration: underline;
           }
         `}

--- a/components/SideNav.tsx
+++ b/components/SideNav.tsx
@@ -22,8 +22,8 @@ export function SideNav() {
               const active = router.pathname === link.href;
               return (
                 <li key={link.href} className={active ? 'active' : ''}>
-                  <Link {...link}>
-                    <a href={link.href}>{link.children}</a>
+                  <Link href={link.href}>
+                    {link.children}
                   </Link>
                 </li>
               );
@@ -54,11 +54,11 @@ export function SideNav() {
             list-style: none;
             margin: 0;
           }
-          li a {
+         :global(.sidenav li a) {
             text-decoration: none;
           }
-          li a:hover,
-          li.active > a {
+          :global(.sidenav li a:hover),
+          :global(.sidenav li.active > a) {
             text-decoration: underline;
           }
         `}

--- a/components/TableOfContents.tsx
+++ b/components/TableOfContents.tsx
@@ -54,11 +54,11 @@ export function TableOfContents({toc}) {
             list-style-type: none;
             margin: 0 0 1rem;
           }
-          :global(.toc li a) {
+          li :global(a) {
             text-decoration: none;
           }
-          :global(.toc li a:hover),
-          :global(.toc li.active a) {
+          li :global(a:hover),
+          li.active :global(a) {
             text-decoration: underline;
           }
           li.padded {

--- a/components/TableOfContents.tsx
+++ b/components/TableOfContents.tsx
@@ -27,8 +27,8 @@ export function TableOfContents({toc}) {
                 .filter(Boolean)
                 .join(' ')}
             >
-              <Link href={href} passHref>
-                <a>{item.title}</a>
+              <Link href={href}>
+                {item.title}
               </Link>
             </li>
           );
@@ -54,11 +54,11 @@ export function TableOfContents({toc}) {
             list-style-type: none;
             margin: 0 0 1rem;
           }
-          li a {
+          :global(.toc li a) {
             text-decoration: none;
           }
-          li a:hover,
-          li.active a {
+          :global(.toc li a:hover),
+          :global(.toc li.active a) {
             text-decoration: underline;
           }
           li.padded {


### PR DESCRIPTION
Hi, this starter installs the latest Next.js version, as seen in package.json, which means it will install Next.js 13 now. Next.js 13  introduces a [new `<Link>` component](https://beta.nextjs.org/docs/upgrade-guide#link-component), which can no longer has `<a>` as its child, otherwise the app will crash. 

This pull request removes `<a>` from `<Link>`, and accordingly change the way to style `<Link>` component. `styled-jsx` can't style `<Link>` with className, unless the style is marked as global.